### PR TITLE
Fix issue related to blocking zenpython during monitoring EMC devices

### DIFF
--- a/ZenPacks/zenoss/WBEM/__init__.py
+++ b/ZenPacks/zenoss/WBEM/__init__.py
@@ -1,6 +1,6 @@
 ##############################################################################
 #
-# Copyright (C) Zenoss, Inc. 2012, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2012, 2017, all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
@@ -12,6 +12,7 @@ LOG = logging.getLogger('zen.WBEM')
 
 from Products.ZenModel.ZenPack import ZenPackBase
 from Products.ZenRelations.zPropertyCategory import setzPropertyCategory
+import ZenPacks.zenoss.WBEM.patches
 
 
 # Categorize our zProperties.
@@ -19,6 +20,7 @@ setzPropertyCategory('zWBEMPort', 'WBEM')
 setzPropertyCategory('zWBEMUsername', 'WBEM')
 setzPropertyCategory('zWBEMPassword', 'WBEM')
 setzPropertyCategory('zWBEMUseSSL', 'WBEM')
+setzPropertyCategory('zWBEMRequestTimeout', 'WBEM')
 
 
 class ZenPack(ZenPackBase):
@@ -29,4 +31,5 @@ class ZenPack(ZenPackBase):
         ('zWBEMUsername', '', 'string'),
         ('zWBEMPassword', '', 'password'),
         ('zWBEMUseSSL', True, 'boolean'),
-        ]
+        ('zWBEMRequestTimeout', '290', 'int'),
+    ]

--- a/ZenPacks/zenoss/WBEM/modeler/wbem.py
+++ b/ZenPacks/zenoss/WBEM/modeler/wbem.py
@@ -139,6 +139,21 @@ class WBEMPlugin(PythonPlugin):
 
             return results
 
+        try:
+            results_new = []
+            for success, instances in results:
+                if success:
+                    inst = []
+                    for instance in instances:
+                        inst.append(instance.__dict__)
+                    results_new.append((success, inst))
+                else:
+                    results_new.append((success, instances))
+
+            log.debug('Results: {0}'.format(results_new))
+        except:
+            pass
+
         return results
 
 


### PR DESCRIPTION
Fixes ZPS-493.

In some cases, requests to the target system can take too much time,
and it can increase the number of running zenpython tasks.
In order to prevent that a timeout for WBEM calls during monitoring was added.