### PR TITLE
ZPS-2595: Update log message if context not found.

### DIFF
--- a/ZenPacks/zenoss/WBEM/patches.py
+++ b/ZenPacks/zenoss/WBEM/patches.py
@@ -40,9 +40,10 @@ class HandleResponseMixin():
         if error is not None:
             msg = error.get('DESCRIPTION')
             if msg and "context cannot be found" in msg:
-                error.set(
-                    'DESCRIPTION',
-                    "Response is not complete for {} classname".format(self.classname)
+                error.set("DESCRIPTION",
+                          "Response is not complete for {} classname. "
+                          "Please check zWBEMOperationTimeout and "
+                          "zWBEMMaxObjectCount properties".format(self.classname)
                 )
         else:
             self.deferred.callback(self.parseResponse(xml))


### PR DESCRIPTION
Fixes https://jira.zenoss.com/browse/ZPS-2595.

Explicitly show which zProperties may cause
"Response is not complete" messages in logs.