### PR TITLE
Fixing Monitoring for EMC anf Proliant via WBEM 3.0.0  

### DIFF
--- a/ZenPacks/zenoss/WBEM/datasources/WBEMDataSource.py
+++ b/ZenPacks/zenoss/WBEM/datasources/WBEMDataSource.py
@@ -59,7 +59,6 @@ def string_to_lines(string):
 
     return None
 
-
 class WBEMDataSource(PythonDataSource):
     """Datasource used to capture datapoints from WBEM providers."""
 
@@ -101,14 +100,19 @@ class WBEMDataSourcePlugin(PythonDataSourcePlugin):
     def loadDependencies(self):
         try:
             global pywbem
-            if not pywbem:
-                from ZenPacks.zenoss.WBEM import dependencies
-                dependencies.import_wbem_libs()
-                from pywbem import CIMDateTime
-                from pywbem.twisted_agent import (
-                    ExecQuery,
-                    OpenEnumerateInstances,
-                )
+            if pywbem:
+                pass
+        except:
+            from ZenPacks.zenoss.WBEM import dependencies
+            dependencies.import_wbem_libs()
+            import pywbem
+
+        try:
+            from pywbem import CIMDateTime
+            from pywbem.twisted_agent import (
+                ExecQuery,
+                OpenEnumerateInstances,
+            )
         except:
             log.error('Errors encountered when loading WBEM dependencies')
 
@@ -189,6 +193,7 @@ class WBEMDataSourcePlugin(PythonDataSourcePlugin):
                 ResultComponentKey=ds0.params['result_component_key']
             )
         else:
+            from pywbem.twisted_agent import ExecQuery
             factory = ExecQuery(
                 credentials,
                 ds0.params['query_language'],

--- a/ZenPacks/zenoss/WBEM/dependencies.py
+++ b/ZenPacks/zenoss/WBEM/dependencies.py
@@ -61,11 +61,6 @@ Due to EMC.base zenpacks' immediate dependency on pywbem (due to __init__.py) th
 have the dynamic libraries loaded at launch.  Thus the runtime-dynamic link is not needed.
 Instead we will import the dependencies on launch
 
-'''
-Due to EMC.base zenpacks' immediate dependency on pywbem (due to __init__.py) this WBEM zenpack must
-have the dynamic libraries loaded at launch.  Thus the runtime-dynamic link is not needed.
-Instead we will import the dependencies on launch
-
 def link_CIMDateTime():
     global datetime_patched
     if not datetime_patched:
@@ -74,3 +69,4 @@ def link_CIMDateTime():
         class CIMDateTime(pywbem.CIMDateTime):
             # WBEMDataSources.CIMDateTime should derive from pywbem.CIMDateTime via dynamic dependencies
             pass
+'''

--- a/ZenPacks/zenoss/WBEM/dependencies.py
+++ b/ZenPacks/zenoss/WBEM/dependencies.py
@@ -61,6 +61,11 @@ Due to EMC.base zenpacks' immediate dependency on pywbem (due to __init__.py) th
 have the dynamic libraries loaded at launch.  Thus the runtime-dynamic link is not needed.
 Instead we will import the dependencies on launch
 
+'''
+Due to EMC.base zenpacks' immediate dependency on pywbem (due to __init__.py) this WBEM zenpack must
+have the dynamic libraries loaded at launch.  Thus the runtime-dynamic link is not needed.
+Instead we will import the dependencies on launch
+
 def link_CIMDateTime():
     global datetime_patched
     if not datetime_patched:
@@ -69,4 +74,3 @@ def link_CIMDateTime():
         class CIMDateTime(pywbem.CIMDateTime):
             # WBEMDataSources.CIMDateTime should derive from pywbem.CIMDateTime via dynamic dependencies
             pass
-'''

--- a/ZenPacks/zenoss/WBEM/patches.py
+++ b/ZenPacks/zenoss/WBEM/patches.py
@@ -80,3 +80,4 @@ class PullInstances(HandleResponseMixin, pywbem.twisted_agent.PullInstances):
 
 class OpenEnumerateInstances(HandleResponseMixin, pywbem.twisted_agent.OpenEnumerateInstances):
     pass
+

--- a/ZenPacks/zenoss/WBEM/patches.py
+++ b/ZenPacks/zenoss/WBEM/patches.py
@@ -80,4 +80,3 @@ class PullInstances(HandleResponseMixin, pywbem.twisted_agent.PullInstances):
 
 class OpenEnumerateInstances(HandleResponseMixin, pywbem.twisted_agent.OpenEnumerateInstances):
     pass
-


### PR DESCRIPTION
Feature/zps-6127
https://jira.zenoss.com/browse/ZPS-6127

inside the pywbemz-0.14.3, the twisted_agent and twisted_client needed to update how they parse tuples.  Essentially, it was just updating a lib-pathing issue:
OLD:    pywbem.tupleparser.parse_thing(x)
NEW:   pywbem.tupleparser.TupleParser().parse_thing(x) 